### PR TITLE
loger aussi les autorisations par exception + PSR + ferme #3965

### DIFF
--- a/ecrire/inc/autoriser.php
+++ b/ecrire/inc/autoriser.php
@@ -168,7 +168,7 @@ function autoriser_dist($faire, $type = '', $id = 0, $qui = null, $opt = null) {
 	if (isset($GLOBALS['autoriser_exception'][$faire][$type][$id])
 		and autoriser_exception($faire, $type, $id, 'verifier')
 	) {
-		spip_log("autoriser ($faire,$type,$id," . (isset($qui['nom']) ? $qui['nom'] : '') . "): OK Exception',"autoriser"._LOG_DEBUG);
+		spip_log("autoriser ($faire,$type,$id," . (isset($qui['nom']) ? $qui['nom'] : '') . '): OK Exception','autoriser'._LOG_DEBUG);
 		return true;
 	}
 

--- a/ecrire/inc/autoriser.php
+++ b/ecrire/inc/autoriser.php
@@ -168,7 +168,7 @@ function autoriser_dist($faire, $type = '', $id = 0, $qui = null, $opt = null) {
 	if (isset($GLOBALS['autoriser_exception'][$faire][$type][$id])
 		and autoriser_exception($faire, $type, $id, 'verifier')
 	) {
-		spip_log("autoriser ($faire,$type,$id," . (isset($qui['nom']) ? $qui['nom'] : '') . '): OK Exception','autoriser'._LOG_DEBUG);
+		spip_log("autoriser ($faire, $type, $id, " . (isset($qui['nom']) ? $qui['nom'] : '') . ') : OK Exception', 'autoriser' . _LOG_DEBUG);
 		return true;
 	}
 
@@ -201,7 +201,7 @@ function autoriser_dist($faire, $type = '', $id = 0, $qui = null, $opt = null) {
 	}
 
 	spip_log(
-		"$f($faire,$type,$id," . (isset($qui['nom']) ? $qui['nom'] : '') . '): ' . ($a ? 'OK' : 'niet'),
+		"$f($faire, $type, $id, " . (isset($qui['nom']) ? $qui['nom'] : '') . ') : ' . ($a ? 'OK' : 'niet'),
 		'autoriser' . _LOG_DEBUG
 	);
 

--- a/ecrire/inc/autoriser.php
+++ b/ecrire/inc/autoriser.php
@@ -168,6 +168,7 @@ function autoriser_dist($faire, $type = '', $id = 0, $qui = null, $opt = null) {
 	if (isset($GLOBALS['autoriser_exception'][$faire][$type][$id])
 		and autoriser_exception($faire, $type, $id, 'verifier')
 	) {
+		spip_log("autoriser ($faire,$type,$id," . (isset($qui['nom']) ? $qui['nom'] : '') . "): OK Exception',"autoriser"._LOG_DEBUG);
 		return true;
 	}
 


### PR DESCRIPTION
Les autorisations sont logées, mais les exceptions d'autorisations ne l'étaient pas ( https://core.spip.net/issues/3965 )

Ce commit répare cette injustice et s'assure que les exceptions ne font pas exception.

On essaie de respecter PSR sur la ligne de code ajoutée et sur une autre dont elle est issue par copier coller.
