### PR TITLE
Meta cache_signature trop restrictive

### DIFF
--- a/ecrire/public/cacher.php
+++ b/ecrire/public/cacher.php
@@ -73,14 +73,19 @@ function lire_cache($nom_cache) {
 // Parano : on signe le cache, afin d'interdire un hack d'injection
 // dans notre memcache
 function cache_signature(&$page) {
-	if (!isset($GLOBALS['meta']['cache_signature'])) {
+	static $meta_cache_signature = NULL;
+
+	if (!isset($meta_cache_signature))
+		$meta_cache_signature = sprintf('cache_signature_%08x', crc32($_SERVER['DOCUMENT_ROOT'] . $_SERVER['SERVER_NAME'] . $_SERVER['SERVER_ADDR'] . $_SERVER['SERVER_PORT']));
+
+	if (!isset($GLOBALS['meta'][$meta_cache_signature])) {
 		include_spip('inc/acces');
 		include_spip('auth/sha256.inc');
-		ecrire_meta('cache_signature',
+		ecrire_meta($meta_cache_signature,
 			_nano_sha256($_SERVER["DOCUMENT_ROOT"] . $_SERVER["SERVER_SIGNATURE"] . creer_uniqid()), 'non');
 	}
 
-	return crc32($GLOBALS['meta']['cache_signature'] . $page['texte']);
+	return crc32($GLOBALS['meta'][$meta_cache_signature] . $page['texte']);
 }
 
 /**


### PR DESCRIPTION
La meta cache_signature n'envisage pas que la base puisse être
utilisée avec plusieurs caches différents. Cette situation peut
exister si on a plusieurs VirtualHost utilisant la même base, ou
bien si une base est répliquée entre plusieurs machines servant le
même site (installation haute dispo).

L'utilisation de la même meta pour contrôler plusieurs caches va
provoquer soit des recalculs inutiles, soit des conflits de
réplication de base de donnée.

Le problème peut être évité en suffixant le nom de la meta par un
identifiant dépendant du VirtualHost et de la machine, ce que fait
cette modification.

Anomalie #3988: meta cache_signature trop restrictive
https://core.spip.net/issues/3988#change-13138