### PR TITLE
Actualiser la regexp de nettoyer_uri_var

### DIFF
--- a/ecrire/inc/utils.php
+++ b/ecrire/inc/utils.php
@@ -633,6 +633,9 @@ function nettoyer_uri($reset = null) {
 
 /**
  * Nettoie une request_uri des paramètres var_xxx
+ * 
+ * Attention, la regexp doit suivre _CONTEXTE_IGNORE_VARIABLES défini au début de public/assembler.php
+ * 
  * @param $request_uri
  * @return string
  */
@@ -640,7 +643,7 @@ function nettoyer_uri_var($request_uri) {
 	$uri1 = $request_uri;
 	do {
 		$uri = $uri1;
-		$uri1 = preg_replace(',([?&])(PHPSESSID|(var_[^=&]*))=[^&]*(&|$),i',
+		$uri1 = preg_replace(',([?&])(var_[^=&]*|PHPSESSID|fbclid|utm_[^=&]*)=[^&]*(&|$),i',
 			'\1', $uri);
 	} while ($uri <> $uri1);
 	return preg_replace(',[?&]$,', '', $uri1);

--- a/ecrire/public/assembler.php
+++ b/ecrire/public/assembler.php
@@ -23,6 +23,7 @@ if (!defined('_ECRIRE_INC_VERSION')) {
 	return;
 }
 
+// En cas de modification, il faut aussi actualiser la regexp de nettoyer_uri_var() dans inc/utils.php
 if (!defined('_CONTEXTE_IGNORE_VARIABLES')) {
 	define('_CONTEXTE_IGNORE_VARIABLES', "/(^var_|^PHPSESSID$|^fbclid$|^utm_)/");
 }


### PR DESCRIPTION
La regexp de nettoyer_uri_var doit rester synchro avec le define faite au début de public assembler
sinon des fbclid se retrouvent inutilement dans les actions des formulaires notamment.

Rq : Il serait possible d'éditer automatiquement la define par remplacement de motifs pour s'en servir dans nettoyer_uri_var.


